### PR TITLE
Switch from golang to alpine based Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM golang:1.8
+FROM alpine:3.5
 MAINTAINER Nic Cope <n+docker@rk0n.org>
 
 ENV APP /kubernary
+
+# These are necessary to connect to AWS.
+# TODO(negz): Don't do this on every build?
+RUN apk update && apk add ca-certificates
 
 RUN mkdir -p "${APP}"
 COPY "dist/kubernary" "${APP}"


### PR DESCRIPTION
There's no reason to use the golang image unless we're building go code at build time, which we are not.